### PR TITLE
feat: mobile scroll-spotlight pops the centered Pokemon card

### DIFF
--- a/hooks/useCenterSpotlight.ts
+++ b/hooks/useCenterSpotlight.ts
@@ -14,6 +14,9 @@ const isTouchDevice = (): boolean =>
 // Used to mirror the desktop hover "pop" as the user scrolls the list.
 const useCenterSpotlight = (ref: RefObject<Element | null>): boolean => {
   // Evaluated once after mount (avoids SSR/client mismatch and desktop work).
+  // Not reactive to mid-session input changes (e.g. attaching a keyboard to a
+  // tablet) — touch-capability rarely flips while browsing, so a listener isn't
+  // worth the cost.
   const [touch, setTouch] = useState(false);
   useEffect(() => setTouch(isTouchDevice()), []);
 

--- a/ui/components/Pokemon/Pokemon.module.css
+++ b/ui/components/Pokemon/Pokemon.module.css
@@ -219,3 +219,22 @@
   text-align: right;
   opacity: 0.95;
 }
+
+/* Mobile scroll-spotlight: the card crossing the viewport center gets the same
+   "pop" as desktop hover. Touch-only — desktop drives this via :hover instead. */
+@media (hover: none) and (pointer: coarse) {
+  .card.cardFocused {
+    transform: translateY(-5px);
+    box-shadow: 0 24px 46px rgba(0, 0, 0, 0.55);
+  }
+  .card.cardFocused .heroImg {
+    transform: scale(1.07) translateY(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card.cardFocused,
+  .card.cardFocused .heroImg {
+    transform: none;
+  }
+}

--- a/ui/components/Pokemon/Pokemon.module.css
+++ b/ui/components/Pokemon/Pokemon.module.css
@@ -233,7 +233,12 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .card.cardFocused,
+  .card.cardFocused {
+    transform: none;
+    /* Reset the shadow too — a shadow fade as the card crosses center is still
+       a "pop", which opt-out users shouldn't get. */
+    box-shadow: 0 16px 34px rgba(0, 0, 0, 0.45);
+  }
   .card.cardFocused .heroImg {
     transform: none;
   }

--- a/ui/components/Pokemon/Pokemon.tsx
+++ b/ui/components/Pokemon/Pokemon.tsx
@@ -59,7 +59,7 @@ const Pokemon = ({
       ref={cardRef}
       href={`${DETAILS}${id}`}
       prefetch
-      className={`${styles.card} ${isFocused ? styles.cardFocused : ""}`}
+      className={isFocused ? `${styles.card} ${styles.cardFocused}` : styles.card}
       style={{ "--type": cardColor } as CSSProperties}
     >
       <span className={styles.watermark} aria-hidden="true">

--- a/ui/components/Pokemon/Pokemon.tsx
+++ b/ui/components/Pokemon/Pokemon.tsx
@@ -1,7 +1,8 @@
-import { memo, useState, type CSSProperties } from "react";
+import { memo, useRef, useState, type CSSProperties } from "react";
 import Link from "next/link";
 import { getPokemonPrimaryTypeColor } from "../../../utils/pokemonFormatter/pokemonFormatter";
 import { usePokemonPic } from "../../../hooks/usePokemonPic";
+import useCenterSpotlight from "../../../hooks/useCenterSpotlight";
 import { formatNumberToMatchLength } from "../../../utils/stringManipulation";
 import { DETAILS } from "../../../constants/Routes";
 import pokemonTypesColor from "../../../constants/TypesColor.json";
@@ -23,6 +24,8 @@ const Pokemon = ({
 }: IBasicPokemon & { priority?: boolean }) => {
   const imageUrl = usePokemonPic(pixelImageUrl, hdImageUrl);
   const [heroLoaded, setHeroLoaded] = useState(false);
+  const cardRef = useRef<HTMLAnchorElement | null>(null);
+  const isFocused = useCenterSpotlight(cardRef);
 
   // If the image is already complete on mount (preloaded or HTTP-cached), the
   // load event has already fired and onLoad never runs — mark it loaded here.
@@ -53,9 +56,10 @@ const Pokemon = ({
 
   return (
     <Link
+      ref={cardRef}
       href={`${DETAILS}${id}`}
       prefetch
-      className={styles.card}
+      className={`${styles.card} ${isFocused ? styles.cardFocused : ""}`}
       style={{ "--type": cardColor } as CSSProperties}
     >
       <span className={styles.watermark} aria-hidden="true">


### PR DESCRIPTION
## What

On touch devices, the Pokemon list card crossing the viewport's vertical center now "pops" with the same lift/scale as the existing desktop hover — a spotlight that follows the scroll. Desktop is unchanged (hover still drives it there).

## How

- **`useCenterSpotlight` hook** (already on master via the perf merge): wraps the existing `useIntersectionObserver` with a zero-height center-line `rootMargin: "-50% 0px -50% 0px"`, so exactly the card straddling center is "focused". Gated to touch via `matchMedia("(hover: none) and (pointer: coarse)")`; returns `false` on desktop/SSR.
- **`Pokemon.tsx`**: attaches a ref to the card `<Link>` and toggles a `cardFocused` class from the hook.
- **`Pokemon.module.css`**: `.cardFocused` reuses the hover transform values verbatim (`translateY(-5px)`, hero `scale(1.07) translateY(-4px)`), wrapped in `@media (hover: none) and (pointer: coarse)` — a second lock so it's inert on desktop. A `prefers-reduced-motion: reduce` guard resets both the transform and the shadow so opt-out users get no pop.

## Verification

No JS test framework in this repo — verified via `tsc --noEmit` (clean) and a headless-Chrome (CDP) run:
- **Touch** (`hover:none/pointer:coarse`): exactly one card focused — the centered one — with `transform: translateY(-5px)`.
- **Desktop** (`hover:hover/pointer:fine`): zero cards focused, transform `none`.
- **Reduced-motion**: class applies but transform is `none` and shadow returns to base.

Spec & plan: `docs/superpowers/specs/2026-06-18-scroll-spotlight-mobile-design.md`, `docs/superpowers/plans/2026-06-18-scroll-spotlight-mobile.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)